### PR TITLE
Freeze current state before storing

### DIFF
--- a/isolator_injection_init.py
+++ b/isolator_injection_init.py
@@ -38,7 +38,7 @@ import pyopencl.array as cla  # noqa
 import math
 from functools import partial
 
-from arraycontext import thaw
+from arraycontext import thaw, freeze
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
@@ -1100,6 +1100,7 @@ def main(ctx_factory=cl.create_some_context, user_input_file=None,
     current_cv = bulk_init(discr=discr, x_vec=thaw(discr.nodes(), actx),
                            eos=eos, time=0)
     current_state = make_fluid_state(current_cv, gas_model, init_temperature)
+    current_state = thaw(freeze(current_state, actx), actx)
 
     visualizer = make_visualizer(discr)
 


### PR DESCRIPTION
This patch avoids some recomputation that's enabled by https://github.com/inducer/arraycontext/pull/158.

```
$ export LOOPY_NO_CACHE=1
$ time python -m mpi4py isolator_injection_init.py -i run_params_combustion.yaml --lazy
real    1m58.600s
user    2m39.182s
sys     0m9.473s
```

The same test used to take ~25 minutes wall-time before this patch.

